### PR TITLE
Phase 4: keyless mode, saved routes, error UX, and connected-component snapping fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ cd canyon-tour
 - `npm install` - Install dependencies
 
 ### Environment Setup
-- Requires Google Maps API key in `.env` file as `VITE_GOOGLE_MAPS_API_KEY` (see `.env.example`)
+- Google Maps API key in `.env` as `VITE_GOOGLE_MAPS_API_KEY` (see `.env.example`) enables the map preview and Google Directions
+- **Keyless mode**: without a key the app still works end-to-end — geocoding falls back to OSM Nominatim, distance/duration are estimated from the road graph, and the Google Maps share URL + QR code are fully functional; only the map preview is unavailable
 - No backend required - runs entirely in browser
 - **Optional**: Set `VITE_VERBOSE_LOGGING=true` in `.env.local` to enable detailed debug logging
 - Env access is centralized in `src/utils/env.ts` (Vite `import.meta.env`)
@@ -39,11 +40,12 @@ cd canyon-tour
 
 ### UI Components (`src/components/`)
 - `RouteForm.tsx` - start/end inputs + search button
-- `RouteOptionsPanel.tsx` - route option cards + waypoint checkboxes
+- `RouteOptionsPanel.tsx` - route option cards (name, distance, duration) + waypoint checkboxes
 - `CustomWaypoints.tsx` - user-added waypoint management
 - `PreferencesPanel.tsx` - avoid highways/tolls toggles
-- `SharePanel.tsx` - Google Maps/Waze links + QR code
-- `App.tsx` - state owner and map rendering orchestration
+- `SharePanel.tsx` - Google Maps/Waze links + QR code + save button
+- `SavedRoutesPanel.tsx` - localStorage-persisted routes (load/delete)
+- `App.tsx` - state owner, status banner, and map rendering orchestration
 
 ### Key Architectural Components
 
@@ -164,6 +166,8 @@ interface RouteOption {
 - Maximum 10 pin waypoints per route (Google Maps limit headroom); one pin
   per ~6 km of path keeps Google glued to the selected roads
 - Pins are never placed within 1.5 km of start/end (Google handles approach)
+- Endpoints snap per connected component (minimizing combined snap distance)
+  so a nearby disconnected road island can never break routing
 - Start/end must snap to the road graph within 30 km or generation aborts
 - Route options that overlap >95% with an existing option are deduplicated
 

--- a/canyon-tour/scripts/demoGraphRoute.ts
+++ b/canyon-tour/scripts/demoGraphRoute.ts
@@ -13,7 +13,7 @@
 
 import { writeFileSync } from 'fs';
 import { osmClient } from '../src/services/osm/osmClient';
-import { buildRoadGraph, findNearestNode, RoadGraph } from '../src/utils/routing/roadGraph';
+import { buildRoadGraph, snapEndpointsToSharedComponent, RoadGraph } from '../src/utils/routing/roadGraph';
 import {
   findBestPath,
   pathOverlapFraction,
@@ -48,8 +48,12 @@ async function main() {
   const graph = buildRoadGraph(osmData);
   console.log(`\nGraph: ${graph.nodes.size} junction nodes, ${graph.edges.size} edges`);
 
-  const startNode = findNearestNode(graph, START)!;
-  const endNode = findNearestNode(graph, END)!;
+  const snapped = snapEndpointsToSharedComponent(graph, START, END);
+  if (!snapped) {
+    console.error('Could not snap endpoints to a connected road network.');
+    process.exit(1);
+  }
+  const { startNode, endNode } = snapped;
   console.log(`Snapped start to node ${startNode.id}, end to node ${endNode.id}\n`);
 
   const routes: { name: string; path: GraphPath }[] = [];

--- a/canyon-tour/src/App.css
+++ b/canyon-tour/src/App.css
@@ -62,6 +62,23 @@
   }
 }
 
+/* Stack controls above the map on small screens */
+@media (max-width: 768px) {
+  .app-container {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .controls-container {
+    padding: 1rem;
+  }
+
+  .map-container {
+    height: 50vh;
+    min-height: 320px;
+  }
+}
+
 /* Route Option Card Styling */
 .route-option-card {
   background-color: white;

--- a/canyon-tour/src/App.tsx
+++ b/canyon-tour/src/App.tsx
@@ -6,11 +6,18 @@ import RouteOptionsPanel from './components/RouteOptionsPanel';
 import CustomWaypoints from './components/CustomWaypoints';
 import PreferencesPanel from './components/PreferencesPanel';
 import SharePanel, { WazeSegment } from './components/SharePanel';
+import SavedRoutesPanel from './components/SavedRoutesPanel';
 import { Route, RoutePreferences, RouteOption } from './types';
 import { geocodeLocation } from './services/googleMapsService';
 import { fetchOsmRoadData } from './services/osm';
 import { generateScenicRouteOptions } from './utils/routingUtils';
 import { Logger } from './utils/logger';
+import { SavedRoute, getSavedRoutes, saveRoute, deleteSavedRoute } from './utils/savedRoutes';
+
+interface StatusMessage {
+  type: 'error' | 'info' | 'success';
+  text: string;
+}
 
 function App() {
   const [route, setRoute] = useState<Route>({
@@ -28,6 +35,8 @@ function App() {
   const [routeOptions, setRouteOptions] = useState<RouteOption[]>([]);
   const [selectedRouteIndex, setSelectedRouteIndex] = useState<number | null>(null);
   const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<StatusMessage | null>(null);
+  const [savedRoutes, setSavedRoutes] = useState<SavedRoute[]>(() => getSavedRoutes());
   const mapRef = useRef<google.maps.Map | null>(null);
   const directionsRendererRef = useRef<google.maps.DirectionsRenderer | null>(null);
   const markersRef = useRef<google.maps.Marker[]>([]);
@@ -48,35 +57,42 @@ function App() {
     setIsLoadingSuggestions(true);
     setRouteOptions([]);
     setSelectedRouteIndex(null);
+    setStatusMessage(null);
     Logger.info(`Finding scenic routes: "${route.start}" → "${route.end}"`);
     Logger.time('Route Discovery');
 
     try {
       const startCoords = await geocodeLocation(route.start);
+      if (!startCoords) {
+        setStatusMessage({ type: 'error', text: `Couldn't find "${route.start}". Try a more specific address or add a city/state.` });
+        return;
+      }
       const endCoords = await geocodeLocation(route.end);
-
-      if (!startCoords || !endCoords) {
-        Logger.error('Failed to geocode locations');
+      if (!endCoords) {
+        setStatusMessage({ type: 'error', text: `Couldn't find "${route.end}". Try a more specific address or add a city/state.` });
         return;
       }
 
       const roadData = await fetchOsmRoadData(startCoords, endCoords);
 
       if (!roadData) {
-        Logger.warn('No road data found in area');
+        setStatusMessage({ type: 'error', text: 'Could not load road data for this area. The OpenStreetMap service may be busy — try again in a minute.' });
       } else {
         const options = await generateScenicRouteOptions(roadData, startCoords, endCoords, {
           avoidHighways: preferences.avoidHighways,
           avoidTolls: preferences.avoidTolls
         });
         Logger.success(`Generated ${options.length} route options`);
-        setRouteOptions(options);
-        if (options.length > 0) {
+        if (options.length === 0) {
+          setStatusMessage({ type: 'error', text: 'No suitable scenic roads found between these locations. Try locations that are closer together or in a less urban area.' });
+        } else {
+          setRouteOptions(options);
           setSelectedRouteIndex(0);
         }
       }
     } catch (error) {
       Logger.error('Route discovery failed', error);
+      setStatusMessage({ type: 'error', text: 'Something went wrong during route discovery. Check the browser console for details.' });
     } finally {
       Logger.timeEnd('Route Discovery');
       setIsLoadingSuggestions(false);
@@ -169,7 +185,6 @@ function App() {
 
   const handleGenerateRoute = () => {
     if (!route.start || !route.end) {
-      alert('Please enter both start and end locations');
       return;
     }
 
@@ -233,6 +248,33 @@ function App() {
     return segments;
   }, [selectedRoute, route.start, route.end]);
 
+  const handleSaveRoute = () => {
+    if (!routeUrl) return;
+    const waypointLocations = [
+      ...(selectedRoute?.waypoints.filter(wp => wp.checked).map(wp => wp.location) || []),
+      ...route.waypoints.filter(wp => wp.location).map(wp => wp.location),
+    ];
+    const name = selectedRoute
+      ? `${selectedRoute.name}: ${route.start.split(',')[0]} → ${route.end.split(',')[0]}`
+      : `${route.start.split(',')[0]} → ${route.end.split(',')[0]}`;
+    saveRoute({ name, start: route.start, end: route.end, waypointLocations, routeUrl, wazeUrl });
+    setSavedRoutes(getSavedRoutes());
+    setStatusMessage({ type: 'success', text: `Saved "${name}".` });
+  };
+
+  const handleLoadSavedRoute = (saved: SavedRoute) => {
+    setRoute({ start: saved.start, end: saved.end, waypoints: [] });
+    setRouteOptions([]);
+    setSelectedRouteIndex(null);
+    setRouteUrl(saved.routeUrl);
+    setWazeUrl(saved.wazeUrl);
+    setStatusMessage({ type: 'info', text: `Loaded "${saved.name}". Scan the QR code or press "Find Scenic Routes" to regenerate options.` });
+  };
+
+  const handleDeleteSavedRoute = (id: string) => {
+    setSavedRoutes(deleteSavedRoute(id));
+  };
+
   const checkedSuggestionsCount = selectedRoute?.waypoints.filter(wp => wp.checked).length || 0;
 
   return (
@@ -250,6 +292,21 @@ function App() {
             <h2 className="text-2xl font-semibold mb-4">Plan Your Scenic Route</h2>
 
             <div className="space-y-4">
+              {statusMessage && (
+                <div
+                  role="alert"
+                  className={`p-3 rounded-md border text-sm ${
+                    statusMessage.type === 'error'
+                      ? 'bg-red-50 border-red-300 text-red-800'
+                      : statusMessage.type === 'success'
+                        ? 'bg-green-50 border-green-300 text-green-800'
+                        : 'bg-blue-50 border-blue-300 text-blue-800'
+                  }`}
+                >
+                  {statusMessage.text}
+                </div>
+              )}
+
               <RouteForm
                 start={route.start}
                 end={route.end}
@@ -286,7 +343,13 @@ function App() {
             </div>
           </div>
 
-          <SharePanel routeUrl={routeUrl} wazeUrl={wazeUrl} wazeSegments={wazeSegments} />
+          <SharePanel routeUrl={routeUrl} wazeUrl={wazeUrl} wazeSegments={wazeSegments} onSave={handleSaveRoute} />
+
+          <SavedRoutesPanel
+            savedRoutes={savedRoutes}
+            onLoad={handleLoadSavedRoute}
+            onDelete={handleDeleteSavedRoute}
+          />
         </div>
       </div>
       <div className="map-container">

--- a/canyon-tour/src/InteractiveMap.tsx
+++ b/canyon-tour/src/InteractiveMap.tsx
@@ -8,7 +8,7 @@ interface MapProps {
 
 const containerStyle = {
   width: '100%',
-  height: '100vh'
+  height: '100%'
 };
 
 const defaultCenter = {
@@ -16,10 +16,34 @@ const defaultCenter = {
   lng: -117.1611
 };
 
+const MissingKeyNotice: React.FC = () => (
+  <div className="flex items-center justify-center h-full bg-gray-100 p-8">
+    <div className="max-w-md text-center">
+      <div className="text-5xl mb-4">🗺️</div>
+      <h3 className="text-lg font-semibold text-gray-800 mb-2">Map preview unavailable</h3>
+      <p className="text-sm text-gray-600">
+        Add <code className="bg-gray-200 px-1 rounded">VITE_GOOGLE_MAPS_API_KEY</code> to your
+        <code className="bg-gray-200 px-1 rounded ml-1">.env</code> file to display the interactive map.
+        Route discovery, Google Maps links, and QR codes still work without it.
+      </p>
+    </div>
+  </div>
+);
+
 const InteractiveMap: React.FC<MapProps> = ({ onLoad }) => {
+  const apiKey = getGoogleMapsApiKey();
+
+  if (!apiKey) {
+    return <MissingKeyNotice />;
+  }
+
+  return <LoadedMap apiKey={apiKey} onLoad={onLoad} />;
+};
+
+const LoadedMap: React.FC<MapProps & { apiKey: string }> = ({ apiKey, onLoad }) => {
   const { isLoaded } = useJsApiLoader({
     id: 'google-map-script',
-    googleMapsApiKey: getGoogleMapsApiKey() || ''
+    googleMapsApiKey: apiKey
   });
 
   return isLoaded ? (
@@ -37,4 +61,4 @@ const InteractiveMap: React.FC<MapProps> = ({ onLoad }) => {
   ) : <div />;
 };
 
-export default InteractiveMap; 
+export default InteractiveMap;

--- a/canyon-tour/src/components/SavedRoutesPanel.tsx
+++ b/canyon-tour/src/components/SavedRoutesPanel.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { SavedRoute } from '../utils/savedRoutes';
+
+interface SavedRoutesPanelProps {
+  savedRoutes: SavedRoute[];
+  onLoad: (route: SavedRoute) => void;
+  onDelete: (id: string) => void;
+}
+
+const SavedRoutesPanel: React.FC<SavedRoutesPanelProps> = ({ savedRoutes, onLoad, onDelete }) => {
+  if (savedRoutes.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-lg shadow-lg p-6 mb-6">
+      <h2 className="text-2xl font-semibold mb-4">💾 Saved Routes</h2>
+      <div className="space-y-2">
+        {savedRoutes.map(route => (
+          <div key={route.id} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-md p-3">
+            <div className="flex-1 min-w-0">
+              <div className="font-medium text-gray-800 truncate">{route.name}</div>
+              <div className="text-xs text-gray-500 truncate">
+                {route.start} → {route.end} · {route.waypointLocations.length} waypoints ·{' '}
+                {new Date(route.savedAt).toLocaleDateString()}
+              </div>
+            </div>
+            <div className="flex items-center space-x-2 ml-3">
+              <button
+                onClick={() => onLoad(route)}
+                className="px-3 py-1 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700 transition-colors"
+              >
+                Load
+              </button>
+              <button
+                onClick={() => onDelete(route.id)}
+                className="px-3 py-1 bg-red-500 text-white text-sm rounded-md hover:bg-red-600 transition-colors"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SavedRoutesPanel;

--- a/canyon-tour/src/components/SharePanel.tsx
+++ b/canyon-tour/src/components/SharePanel.tsx
@@ -11,14 +11,23 @@ interface SharePanelProps {
   routeUrl: string;
   wazeUrl: string;
   wazeSegments: WazeSegment[];
+  onSave: () => void;
 }
 
-const SharePanel: React.FC<SharePanelProps> = ({ routeUrl, wazeUrl, wazeSegments }) => {
+const SharePanel: React.FC<SharePanelProps> = ({ routeUrl, wazeUrl, wazeSegments, onSave }) => {
   if (!routeUrl) return null;
 
   return (
-    <div className="bg-white rounded-lg shadow-lg p-6">
-      <h2 className="text-2xl font-semibold mb-4">Your Twisty Canyon Route</h2>
+    <div className="bg-white rounded-lg shadow-lg p-6 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-2xl font-semibold">Your Twisty Canyon Route</h2>
+        <button
+          onClick={onSave}
+          className="px-3 py-1 bg-amber-500 text-white text-sm rounded-md hover:bg-amber-600 transition-colors"
+        >
+          💾 Save Route
+        </button>
+      </div>
 
       <div className="mb-4">
         <h3 className="text-lg font-medium text-gray-800">Google Maps Route</h3>

--- a/canyon-tour/src/services/__tests__/googleMapsService.test.ts
+++ b/canyon-tour/src/services/__tests__/googleMapsService.test.ts
@@ -64,13 +64,33 @@ describe('googleMapsService', () => {
       expect(result).toBeNull();
     });
 
-    it('should handle missing API key', async () => {
+    it('should fall back to Nominatim when no API key is set', async () => {
       vi.stubEnv('VITE_GOOGLE_MAPS_API_KEY', '');
 
-      const result = await geocodeLocation('jamul casino');
-      
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ lat: '32.7171', lon: '-116.876' }]
+      });
+
+      const result = await geocodeLocation('Jamul, CA');
+
+      expect(result).toEqual({ lat: 32.7171, lon: -116.876 });
+      const requestedUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(requestedUrl).toContain('nominatim.openstreetmap.org');
+      expect(requestedUrl).not.toContain('key=');
+    });
+
+    it('should return null when Nominatim finds nothing (no API key)', async () => {
+      vi.stubEnv('VITE_GOOGLE_MAPS_API_KEY', '');
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => []
+      });
+
+      const result = await geocodeLocation('nowhere at all xyz');
+
       expect(result).toBeNull();
-      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/canyon-tour/src/services/googleMapsService.ts
+++ b/canyon-tour/src/services/googleMapsService.ts
@@ -2,14 +2,15 @@ import { calculateDistance } from '../utils/routingUtils';
 import { getGoogleMapsApiKey } from '../utils/env';
 
 export const geocodeLocation = async (location: string): Promise<{ lat: number; lon: number } | null> => {
+    const apiKey = getGoogleMapsApiKey();
+    if (!apiKey) {
+      // Keyless mode: fall back to OSM Nominatim so route discovery still works.
+      console.log('1. Geocoding location with Nominatim (no Google API key set):', location);
+      return geocodeWithNominatim(location);
+    }
+
     console.log('1. Geocoding location with Google API:', location);
     try {
-      const apiKey = getGoogleMapsApiKey();
-      if (!apiKey) {
-        console.error('❌ FATAL: Google Maps API key not found. Please set VITE_GOOGLE_MAPS_API_KEY.');
-        return null;
-      }
-
       const url = `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(location)}&key=${apiKey}`;
 
       const response = await fetch(url);
@@ -38,6 +39,30 @@ export const geocodeLocation = async (location: string): Promise<{ lat: number; 
       return null;
     }
   };
+
+const geocodeWithNominatim = async (location: string): Promise<{ lat: number; lon: number } | null> => {
+  try {
+    const url = `https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(location)}`;
+    const response = await fetch(url, {
+      headers: { 'Accept': 'application/json' }
+    });
+    if (!response.ok) {
+      console.error('  - ❌ Nominatim request failed:', response.status, response.statusText);
+      return null;
+    }
+    const results = await response.json();
+    if (Array.isArray(results) && results.length > 0) {
+      const coords = { lat: parseFloat(results[0].lat), lon: parseFloat(results[0].lon) };
+      console.log('  - ✅ Successfully geocoded via Nominatim:', location, '→', coords);
+      return coords;
+    }
+    console.log('  - ❌ Nominatim found no results for:', location);
+    return null;
+  } catch (error) {
+    console.error('  - ❌ Nominatim geocoding error:', error);
+    return null;
+  }
+};
 
 export const getEnhancedRouteBoundingBoxFromCoords = async (startCoords: { lat: number, lon: number }, endCoords: { lat: number, lon: number }): Promise<string | null> => {
   console.log('2. Calculating enhanced route bounding box from coordinates...');

--- a/canyon-tour/src/utils/routing/graphRouteGenerator.test.ts
+++ b/canyon-tour/src/utils/routing/graphRouteGenerator.test.ts
@@ -72,6 +72,21 @@ describe('generateScenicRouteOptions', () => {
     expect(summarize(second)).toEqual(summarize(first));
   });
 
+  test('still produces route options with estimates when Directions is unavailable (keyless mode)', async () => {
+    getDirectionsMock.mockResolvedValue(null);
+
+    const options = await generateScenicRouteOptions(buildSyntheticNetwork(), start, end);
+
+    expect(options.length).toBeGreaterThanOrEqual(2);
+    options.forEach(option => {
+      expect(option.directions).toBeUndefined();
+      // Estimates come from the graph path itself.
+      expect(option.distance).toBeGreaterThan(5);
+      expect(option.duration).toBeGreaterThan(0);
+      expect(option.waypoints.length).toBeGreaterThan(0);
+    });
+  });
+
   test('returns empty list when the area has no suitable roads', async () => {
     const options = await generateScenicRouteOptions({ elements: [] }, start, end);
     expect(options).toEqual([]);

--- a/canyon-tour/src/utils/routing/graphRouteGenerator.ts
+++ b/canyon-tour/src/utils/routing/graphRouteGenerator.ts
@@ -1,6 +1,6 @@
 import { Coordinates, RouteOption, SuggestedWaypoint } from '../../types';
 import { buildRoadGraph, findNearestNode, RoadGraph } from './roadGraph';
-import { findBestPath, pathOverlapFraction, GraphPath, ROUTE_PROFILES, RouteProfile } from './graphRouter';
+import { findBestPath, pathOverlapFraction, parseMaxSpeedMph, GraphPath, ROUTE_PROFILES, RouteProfile } from './graphRouter';
 import { calculateDistance, getStrategicRoutingDescription } from './geoUtils';
 import { getDirections, DirectionsOptions } from '../../services/googleMapsService';
 import { analyzeRouteForOutAndBack, calculateRouteContinuity } from './routeAnalysis';
@@ -84,30 +84,33 @@ export async function generateScenicRouteOptions(
     const waypoints = pathToWaypoints(path, profile);
     const waypointCoords = waypoints.map(wp => wp.coordinates!);
     const directions = await getDirections(start, end, waypointCoords, directionsOptions);
-    if (!directions) {
-      console.warn(`Could not fetch directions for ${profile.name}.`);
-      continue;
-    }
 
-    const routeAnalysis = analyzeRouteForOutAndBack(directions);
-    const continuityScore = calculateRouteContinuity(directions);
-    const totalDistance = directions.routes[0].legs.reduce((sum, leg) => sum + (leg.distance?.value || 0), 0);
-    const totalDuration = directions.routes[0].legs.reduce((sum, leg) => sum + (leg.duration?.value || 0), 0);
-
-    options.push({
+    const option: RouteOption = {
       name: `${profile.name}${nameSuffix ?? ''}`,
       strategy: profile.name,
       description:
         `${profile.description} ${(path.totalLengthMeters / 1000).toFixed(0)} km of selected roads, ` +
         `average twistiness ${path.averageTwistiness.toFixed(1)}.`,
       waypoints,
-      distance: totalDistance / 1000,
-      duration: totalDuration / 60,
-      directions,
-      continuityScore,
-      routeAnalysis,
       totalTwistiness: path.averageTwistiness,
-    });
+    };
+
+    if (directions) {
+      option.directions = directions;
+      option.routeAnalysis = analyzeRouteForOutAndBack(directions);
+      option.continuityScore = calculateRouteContinuity(directions);
+      option.distance = directions.routes[0].legs.reduce((sum, leg) => sum + (leg.distance?.value || 0), 0) / 1000;
+      option.duration = directions.routes[0].legs.reduce((sum, leg) => sum + (leg.duration?.value || 0), 0) / 60;
+    } else {
+      // Keyless / offline mode: Google Directions is unavailable, but the
+      // graph path itself gives solid estimates and the share URL + QR code
+      // (the app's real output) don't need the Directions API at all.
+      console.warn(`Could not fetch directions for ${profile.name}; using graph path estimates.`);
+      option.distance = path.totalLengthMeters / 1000;
+      option.duration = estimatePathDurationMinutes(path);
+    }
+
+    options.push(option);
   }
 
   // Rank scenic quality first; keep "Most Direct" available as a baseline.
@@ -119,6 +122,28 @@ function rankRoute(option: RouteOption): number {
   const twistiness = option.totalTwistiness || 0;
   const continuity = option.continuityScore || 0.5;
   return twistiness * 3 + continuity * 10;
+}
+
+/** Typical driving speeds (km/h) by OSM road class, used when maxspeed is untagged. */
+const DEFAULT_SPEED_KMH: Record<string, number> = {
+  primary: 90,
+  secondary: 75,
+  tertiary: 65,
+  unclassified: 55,
+  residential: 40,
+};
+
+/** Estimates driving time along a graph path from edge speed limits / road class. */
+export function estimatePathDurationMinutes(path: GraphPath): number {
+  let minutes = 0;
+  for (const edge of path.edges) {
+    const taggedMph = parseMaxSpeedMph(edge.tags.maxspeed);
+    const speedKmh = taggedMph !== null
+      ? taggedMph * 1.60934
+      : DEFAULT_SPEED_KMH[edge.highway] ?? 55;
+    minutes += (edge.lengthMeters / 1000 / speedKmh) * 60;
+  }
+  return minutes;
 }
 
 /**

--- a/canyon-tour/src/utils/routing/graphRouteGenerator.ts
+++ b/canyon-tour/src/utils/routing/graphRouteGenerator.ts
@@ -1,5 +1,5 @@
 import { Coordinates, RouteOption, SuggestedWaypoint } from '../../types';
-import { buildRoadGraph, findNearestNode, RoadGraph } from './roadGraph';
+import { buildRoadGraph, snapEndpointsToSharedComponent, RoadGraph } from './roadGraph';
 import { findBestPath, pathOverlapFraction, parseMaxSpeedMph, GraphPath, ROUTE_PROFILES, RouteProfile } from './graphRouter';
 import { calculateDistance, getStrategicRoutingDescription } from './geoUtils';
 import { getDirections, DirectionsOptions } from '../../services/googleMapsService';
@@ -36,12 +36,12 @@ export async function generateScenicRouteOptions(
     return [];
   }
 
-  const startNode = findNearestNode(graph, start);
-  const endNode = findNearestNode(graph, end);
-  if (!startNode || !endNode || startNode.id === endNode.id) {
-    console.warn('Could not snap start/end to the road graph.');
+  const snapped = snapEndpointsToSharedComponent(graph, start, end);
+  if (!snapped) {
+    console.warn('Could not snap start/end to a connected road network.');
     return [];
   }
+  const { startNode, endNode } = snapped;
   const startSnapDistance = calculateDistance(start, { lat: startNode.lat, lon: startNode.lon });
   const endSnapDistance = calculateDistance(end, { lat: endNode.lat, lon: endNode.lon });
   if (startSnapDistance > MAX_SNAP_DISTANCE_METERS || endSnapDistance > MAX_SNAP_DISTANCE_METERS) {

--- a/canyon-tour/src/utils/routing/roadGraph.test.ts
+++ b/canyon-tour/src/utils/routing/roadGraph.test.ts
@@ -1,4 +1,4 @@
-import { buildRoadGraph, findNearestNode } from './roadGraph';
+import { buildRoadGraph, findNearestNode, snapEndpointsToSharedComponent } from './roadGraph';
 import { findBestPath, ROUTE_PROFILES } from './graphRouter';
 import lyonsValleyFixture from '../../services/osm/__fixtures__/lyons_valley.json';
 import { buildSyntheticNetwork, NODE_A_ID, NODE_B_ID } from '../../testUtils/syntheticOsm';
@@ -118,6 +118,37 @@ describe('findBestPath (synthetic network)', () => {
     const path = findBestPath(graph, NODE_A_ID, NODE_B_ID, twistyProfile)!;
     const uniqueNodes = new Set(path.nodeIds);
     expect(uniqueNodes.size).toBe(path.nodeIds.length);
+  });
+
+  test('endpoint snapping skips disconnected islands (regression: Jamul stub roads)', () => {
+    // Add a tiny isolated residential stub RIGHT at the start coordinates.
+    // Naive nearest-node snapping would pick it and make routing impossible.
+    const network = buildSyntheticNetwork();
+    network.elements.push(
+      { type: 'node', id: 950, lat: 32.70001, lon: -116.90001 },
+      { type: 'node', id: 951, lat: 32.70050, lon: -116.90050 },
+      {
+        type: 'way',
+        id: 4000,
+        nodes: [950, 951],
+        tags: { highway: 'residential', surface: 'asphalt' },
+      }
+    );
+    const graphWithIsland = buildRoadGraph(network);
+
+    const start = { lat: 32.7, lon: -116.9 };   // exactly between island and main network
+    const end = { lat: 32.7, lon: -116.8 };     // only reachable via main network
+
+    // Naive snapping picks the island node (it is at least as close)...
+    const naive = findNearestNode(graphWithIsland, { lat: 32.70001, lon: -116.90001 });
+    expect([950, 951]).toContain(naive!.id);
+
+    // ...but component-aware snapping picks nodes that can actually reach each other.
+    const snapped = snapEndpointsToSharedComponent(graphWithIsland, start, end);
+    expect(snapped).not.toBeNull();
+    const path = findBestPath(graphWithIsland, snapped!.startNode.id, snapped!.endNode.id, ROUTE_PROFILES[0]);
+    expect(path).not.toBeNull();
+    expect(path!.totalLengthMeters).toBeGreaterThan(1000);
   });
 
   test('returns null for disconnected nodes', () => {

--- a/canyon-tour/src/utils/routing/roadGraph.ts
+++ b/canyon-tour/src/utils/routing/roadGraph.ts
@@ -164,13 +164,19 @@ function parseOneway(tags: Record<string, any>): 'no' | 'forward' | 'reverse' {
 /**
  * Finds the graph node closest to the given coordinates. Only considers nodes
  * that participate in at least one edge, so the result is always routable.
+ * Optionally restricted to a set of allowed node IDs.
  */
-export function findNearestNode(graph: RoadGraph, target: Coordinates): GraphNode | null {
+export function findNearestNode(
+  graph: RoadGraph,
+  target: Coordinates,
+  allowedNodes?: Set<number>
+): GraphNode | null {
   let best: GraphNode | null = null;
   let bestDistance = Infinity;
 
   graph.adjacency.forEach((entries, nodeId) => {
     if (entries.length === 0) return;
+    if (allowedNodes && !allowedNodes.has(nodeId)) return;
     const node = graph.nodes.get(nodeId);
     if (!node) return;
     const distance = calculateDistance({ lat: node.lat, lon: node.lon }, target);
@@ -181,4 +187,101 @@ export function findNearestNode(graph: RoadGraph, target: Coordinates): GraphNod
   });
 
   return best;
+}
+
+/**
+ * Labels every routable node with an (undirected) connected-component ID.
+ * Returns the component map plus component sizes.
+ */
+export function computeComponents(graph: RoadGraph): {
+  componentOf: Map<number, number>;
+  componentSizes: Map<number, number>;
+} {
+  const componentOf = new Map<number, number>();
+  const componentSizes = new Map<number, number>();
+  let componentId = 0;
+
+  graph.adjacency.forEach((_, rootId) => {
+    if (componentOf.has(rootId)) return;
+    const queue = [rootId];
+    componentOf.set(rootId, componentId);
+    let size = 0;
+    while (queue.length > 0) {
+      const current = queue.pop()!;
+      size++;
+      for (const { neighbor } of graph.adjacency.get(current) || []) {
+        if (!componentOf.has(neighbor)) {
+          componentOf.set(neighbor, componentId);
+          queue.push(neighbor);
+        }
+      }
+    }
+    componentSizes.set(componentId, size);
+    componentId++;
+  });
+
+  return { componentOf, componentSizes };
+}
+
+/**
+ * Snaps start and end to nodes that are guaranteed to lie in the SAME
+ * connected component, choosing the component that minimizes the combined
+ * snap distance. This prevents an endpoint from latching onto a tiny
+ * disconnected island (e.g. a gated residential stub) that happens to be
+ * geographically closest, which would make routing impossible.
+ */
+export function snapEndpointsToSharedComponent(
+  graph: RoadGraph,
+  start: Coordinates,
+  end: Coordinates
+): { startNode: GraphNode; endNode: GraphNode } | null {
+  const { componentOf, componentSizes } = computeComponents(graph);
+  if (componentSizes.size === 0) return null;
+
+  // Track, per component, the nearest node to each endpoint. Minimizing the
+  // combined snap distance naturally rejects small islands: a fragment near
+  // one endpoint is necessarily far from the other.
+  const nearestToStart = new Map<number, { node: GraphNode; distance: number }>();
+  const nearestToEnd = new Map<number, { node: GraphNode; distance: number }>();
+
+  graph.adjacency.forEach((entries, nodeId) => {
+    if (entries.length === 0) return;
+    const component = componentOf.get(nodeId);
+    if (component === undefined) return;
+
+    const node = graph.nodes.get(nodeId);
+    if (!node) return;
+    const coords = { lat: node.lat, lon: node.lon };
+
+    const startDistance = calculateDistance(coords, start);
+    const bestStart = nearestToStart.get(component);
+    if (!bestStart || startDistance < bestStart.distance) {
+      nearestToStart.set(component, { node, distance: startDistance });
+    }
+
+    const endDistance = calculateDistance(coords, end);
+    const bestEnd = nearestToEnd.get(component);
+    if (!bestEnd || endDistance < bestEnd.distance) {
+      nearestToEnd.set(component, { node, distance: endDistance });
+    }
+  });
+
+  let bestStartNode: GraphNode | null = null;
+  let bestEndNode: GraphNode | null = null;
+  let bestCombined = Infinity;
+  nearestToStart.forEach((startCandidate, component) => {
+    const endCandidate = nearestToEnd.get(component);
+    if (!endCandidate) return;
+    if (startCandidate.node.id === endCandidate.node.id) return;
+    const combined = startCandidate.distance + endCandidate.distance;
+    if (combined < bestCombined) {
+      bestStartNode = startCandidate.node;
+      bestEndNode = endCandidate.node;
+      bestCombined = combined;
+    }
+  });
+
+  return bestStartNode && bestEndNode
+    ? { startNode: bestStartNode, endNode: bestEndNode }
+    : null;
 }

--- a/canyon-tour/src/utils/savedRoutes.test.ts
+++ b/canyon-tour/src/utils/savedRoutes.test.ts
@@ -1,0 +1,52 @@
+import { getSavedRoutes, saveRoute, deleteSavedRoute } from './savedRoutes';
+
+describe('savedRoutes', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('starts empty', () => {
+    expect(getSavedRoutes()).toEqual([]);
+  });
+
+  test('saves and retrieves a route', () => {
+    const saved = saveRoute({
+      name: 'Twisty Explorer: Jamul → Descanso',
+      start: 'Jamul, CA',
+      end: 'Descanso, CA',
+      waypointLocations: ['Lyons Valley Road', 'Japatul Valley Road'],
+      routeUrl: 'https://www.google.com/maps/dir/a/b',
+      wazeUrl: 'https://waze.com/ul?q=Descanso',
+    });
+
+    const routes = getSavedRoutes();
+    expect(routes).toHaveLength(1);
+    expect(routes[0].id).toBe(saved.id);
+    expect(routes[0].name).toBe('Twisty Explorer: Jamul → Descanso');
+    expect(routes[0].waypointLocations).toHaveLength(2);
+    expect(routes[0].savedAt).toBeTruthy();
+  });
+
+  test('newest routes come first', () => {
+    saveRoute({ name: 'first', start: 'a', end: 'b', waypointLocations: [], routeUrl: 'u1', wazeUrl: '' });
+    saveRoute({ name: 'second', start: 'c', end: 'd', waypointLocations: [], routeUrl: 'u2', wazeUrl: '' });
+
+    const routes = getSavedRoutes();
+    expect(routes.map(r => r.name)).toEqual(['second', 'first']);
+  });
+
+  test('deletes a route by id', () => {
+    const keep = saveRoute({ name: 'keep', start: 'a', end: 'b', waypointLocations: [], routeUrl: 'u1', wazeUrl: '' });
+    const remove = saveRoute({ name: 'remove', start: 'c', end: 'd', waypointLocations: [], routeUrl: 'u2', wazeUrl: '' });
+
+    const remaining = deleteSavedRoute(remove.id);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe(keep.id);
+    expect(getSavedRoutes()).toHaveLength(1);
+  });
+
+  test('survives corrupted storage gracefully', () => {
+    localStorage.setItem('canyon-tour-saved-routes', 'not-json{');
+    expect(getSavedRoutes()).toEqual([]);
+  });
+});

--- a/canyon-tour/src/utils/savedRoutes.ts
+++ b/canyon-tour/src/utils/savedRoutes.ts
@@ -1,0 +1,47 @@
+/**
+ * Saved routes persistence (localStorage). Stores the shareable output of a
+ * generated route so it can be reloaded without re-running discovery.
+ */
+
+export interface SavedRoute {
+  id: string;
+  name: string;
+  start: string;
+  end: string;
+  waypointLocations: string[];
+  routeUrl: string;
+  wazeUrl: string;
+  savedAt: string; // ISO timestamp
+}
+
+const STORAGE_KEY = 'canyon-tour-saved-routes';
+
+export function getSavedRoutes(): SavedRoute[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveRoute(route: Omit<SavedRoute, 'id' | 'savedAt'>): SavedRoute {
+  const saved: SavedRoute = {
+    ...route,
+    // Date.now() alone can collide for rapid saves; UUID guarantees uniqueness.
+    id: `route-${crypto.randomUUID()}`,
+    savedAt: new Date().toISOString(),
+  };
+  const routes = getSavedRoutes();
+  routes.unshift(saved);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(routes));
+  return saved;
+}
+
+export function deleteSavedRoute(id: string): SavedRoute[] {
+  const routes = getSavedRoutes().filter(route => route.id !== id);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(routes));
+  return routes;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Final phase of the revival gameplan. Stacked on the Phase 3 PR. The app now works **end-to-end in the browser with zero API keys** — proven with a recorded demo.

### Keyless mode
- Geocoding falls back to OSM Nominatim when no Google key is set (graph routing and Overpass never needed one).
- Route options survive Google Directions failure: distance/duration are estimated from the road graph (edge `maxspeed` or road-class defaults). The app's real output — the Google Maps share URL and QR code — never needed the Directions API.
- The map pane shows a helpful notice instead of a silent blank div when no key is configured.

### Critical routing fix found by end-to-end testing
The recorded browser test initially failed: the Nominatim coordinates for Jamul, CA snapped to a 6-node disconnected residential stub that happened to be geographically nearest, so every route search returned "no path found". Endpoints now snap **per connected component**, minimizing combined snap distance, so start and end are guaranteed to reach each other whenever any connected corridor exists. Covered by a synthetic-island regression test.

### UX features
- **Saved routes** (from `TODO.md` high-priority list): persist generated routes to localStorage with load/delete, newest first. The tests caught and fixed a `Date.now()` ID-collision bug.
- **Status banner**: geocoding failures, Overpass errors, and empty results now show user-visible messages instead of silent console errors; the `alert()` is gone.
- Controls stack above the map on screens narrower than 768 px.

## Walkthrough

[full_demo_route_discovery_qr_save.mp4](https://cursor.com/agents/bc-8ee0e50e-08af-48f2-b2c7-05f23fcd86ff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffull_demo_route_discovery_qr_save.mp4)

Full keyless flow: Jamul → Descanso discovery over live Nominatim + Overpass data, two distinct route options, waypoints on Lyons Valley Road / Japatul Valley Road, QR code generation, and saving/loading the route.

[Route options with distance and duration](https://cursor.com/agents/bc-8ee0e50e-08af-48f2-b2c7-05f23fcd86ff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froute_options_jamul_descanso.webp)
[Share panel with QR code](https://cursor.com/agents/bc-8ee0e50e-08af-48f2-b2c7-05f23fcd86ff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshare_panel_qr_code.webp)
[Saved routes panel](https://cursor.com/agents/bc-8ee0e50e-08af-48f2-b2c7-05f23fcd86ff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsaved_routes_panel.webp)

## Testing
- ✅ `npm test` — 30/30 tests pass (new: Nominatim fallback, keyless route generation, saved-routes persistence, island-snapping regression)
- ✅ `npm run build` — tsc typecheck + Vite build clean
- ✅ Manual GUI test recorded end-to-end against live Nominatim + Overpass APIs (video attached)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ee0e50e-08af-48f2-b2c7-05f23fcd86ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ee0e50e-08af-48f2-b2c7-05f23fcd86ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

