### PR TITLE
feat(keyless): SVG preview, Nominatim autocomplete, route diversity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ cd canyon-tour
 
 ### Environment Setup
 - Google Maps API key in `.env` as `VITE_GOOGLE_MAPS_API_KEY` (see `.env.example`) enables the map preview and Google Directions
-- **Keyless mode**: without a key the app still works end-to-end — geocoding falls back to OSM Nominatim, distance/duration are estimated from the road graph, and the Google Maps share URL + QR code are fully functional; only the map preview is unavailable
+- **Keyless mode**: without a key the app still works end-to-end — geocoding falls back to OSM Nominatim (with search-as-you-type autocomplete), distance/duration are estimated from the road graph, an SVG path preview replaces the Google map, and the Google Maps share URL + QR code are fully functional
 - No backend required - runs entirely in browser
 - **Optional**: Set `VITE_VERBOSE_LOGGING=true` in `.env.local` to enable detailed debug logging
 - Env access is centralized in `src/utils/env.ts` (Vite `import.meta.env`)
@@ -40,7 +40,9 @@ cd canyon-tour
 - **QR Generation**: qrcode.react for sharing routes
 
 ### UI Components (`src/components/`)
-- `RouteForm.tsx` - start/end inputs + search button
+- `RouteForm.tsx` - start/end inputs + search button (with staged loading status)
+- `LocationAutocomplete.tsx` - debounced Nominatim search-as-you-type (keyless)
+- `RoutePreview.tsx` - SVG path preview when no Google Maps key
 - `RouteOptionsPanel.tsx` - route option cards (name, distance, duration) + waypoint checkboxes
 - `CustomWaypoints.tsx` - user-added waypoint management
 - `PreferencesPanel.tsx` - avoid highways/tolls toggles
@@ -86,8 +88,10 @@ Route diversity comes from cost profiles, not waypoint heuristics:
   roads; accepts long detours
 - **Balanced Scenic**: moderate scenic preference with a smaller detour budget
 - **Most Direct**: shortest allowed path (still avoids unpaved/narrow roads)
-- **Twisty Explorer (Alternative)**: re-route with the primary scenic route's
-  edges penalized, kept only if it is meaningfully different (<70% overlap)
+- **Twisty Explorer (Alternative / Alternative 2)**: re-route with escalating
+  penalties on already-chosen edges; kept only if meaningfully different
+  (<70% overlap). Up to two alternatives so corridors with parallel scenic
+  roads still offer choice when base profiles collapse.
 
 #### 4. Road Filtering Logic (from `.cursor/rules/routing.mdc`)
 **Prioritize:**

--- a/canyon-tour/README.md
+++ b/canyon-tour/README.md
@@ -20,8 +20,8 @@ you and your friends can navigate them.
 5. Share the result as a Google Maps URL, QR code, Waze links, or a GPX file.
 
 Route profiles: **Twisty Explorer** (max curves, generous detours),
-**Balanced Scenic**, **Most Direct**, plus a meaningfully different
-**Alternative** scenic route when one exists.
+**Balanced Scenic**, **Most Direct**, plus up to two meaningfully different
+**Alternative** scenic routes when parallel corridors exist.
 
 ## Quick start
 
@@ -44,9 +44,10 @@ distances/times. It needs the **Maps JavaScript API**, **Directions API**, and
 restrictions) since it ships in the browser bundle.
 
 **Keyless mode**: without a key the app still works end-to-end — geocoding
-falls back to OSM Nominatim, distance/duration are estimated from the road
-graph, and the share URL, QR code, and GPX export are fully functional. Only
-the map preview is unavailable.
+falls back to OSM Nominatim (with search-as-you-type autocomplete),
+distance/duration are estimated from the road graph, an SVG path preview
+replaces the Google map, and the share URL, QR code, and GPX export are
+fully functional.
 
 ## Commands
 

--- a/canyon-tour/src/App.tsx
+++ b/canyon-tour/src/App.tsx
@@ -7,12 +7,13 @@ import CustomWaypoints from './components/CustomWaypoints';
 import PreferencesPanel from './components/PreferencesPanel';
 import SharePanel, { WazeSegment } from './components/SharePanel';
 import SavedRoutesPanel from './components/SavedRoutesPanel';
-import { Route, RoutePreferences, RouteOption } from './types';
+import { Route, RoutePreferences, RouteOption, Coordinates } from './types';
 import { geocodeLocation } from './services/googleMapsService';
 import { fetchOsmRoadData } from './services/osm';
 import { generateScenicRouteOptions } from './utils/routingUtils';
 import { Logger } from './utils/logger';
 import { SavedRoute, getSavedRoutes, saveRoute, deleteSavedRoute, renameSavedRoute } from './utils/savedRoutes';
+import type { LocationSuggestion } from './components/LocationAutocomplete';
 
 interface StatusMessage {
   type: 'error' | 'info' | 'success';
@@ -35,6 +36,9 @@ function App() {
   const [routeOptions, setRouteOptions] = useState<RouteOption[]>([]);
   const [selectedRouteIndex, setSelectedRouteIndex] = useState<number | null>(null);
   const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
+  const [loadingStatus, setLoadingStatus] = useState<string | null>(null);
+  const [startCoords, setStartCoords] = useState<Coordinates | null>(null);
+  const [endCoords, setEndCoords] = useState<Coordinates | null>(null);
   const [statusMessage, setStatusMessage] = useState<StatusMessage | null>(null);
   const [savedRoutes, setSavedRoutes] = useState<SavedRoute[]>(() => getSavedRoutes());
   const mapRef = useRef<google.maps.Map | null>(null);
@@ -55,6 +59,7 @@ function App() {
     }
 
     setIsLoadingSuggestions(true);
+    setLoadingStatus('Geocoding…');
     setRouteOptions([]);
     setSelectedRouteIndex(null);
     setStatusMessage(null);
@@ -62,23 +67,37 @@ function App() {
     Logger.time('Route Discovery');
 
     try {
-      const startCoords = await geocodeLocation(route.start);
-      if (!startCoords) {
+      // Reuse coords from autocomplete when available; otherwise geocode the text.
+      let resolvedStart = startCoords;
+      let resolvedEnd = endCoords;
+
+      if (!resolvedStart) {
+        resolvedStart = await geocodeLocation(route.start);
+      }
+      if (!resolvedStart) {
         setStatusMessage({ type: 'error', text: `Couldn't find "${route.start}". Try a more specific address or add a city/state.` });
         return;
       }
-      const endCoords = await geocodeLocation(route.end);
-      if (!endCoords) {
+
+      if (!resolvedEnd) {
+        resolvedEnd = await geocodeLocation(route.end);
+      }
+      if (!resolvedEnd) {
         setStatusMessage({ type: 'error', text: `Couldn't find "${route.end}". Try a more specific address or add a city/state.` });
         return;
       }
 
-      const roadData = await fetchOsmRoadData(startCoords, endCoords);
+      setStartCoords(resolvedStart);
+      setEndCoords(resolvedEnd);
+
+      setLoadingStatus('Fetching roads…');
+      const roadData = await fetchOsmRoadData(resolvedStart, resolvedEnd);
 
       if (!roadData) {
         setStatusMessage({ type: 'error', text: 'Could not load road data for this area. The OpenStreetMap service may be busy — try again in a minute.' });
       } else {
-        const options = await generateScenicRouteOptions(roadData, startCoords, endCoords, {
+        setLoadingStatus('Building routes…');
+        const options = await generateScenicRouteOptions(roadData, resolvedStart, resolvedEnd, {
           avoidHighways: preferences.avoidHighways,
           avoidTolls: preferences.avoidTolls
         });
@@ -96,6 +115,7 @@ function App() {
     } finally {
       Logger.timeEnd('Route Discovery');
       setIsLoadingSuggestions(false);
+      setLoadingStatus(null);
     }
   };
 
@@ -265,11 +285,33 @@ function App() {
 
   const handleLoadSavedRoute = (saved: SavedRoute) => {
     setRoute({ start: saved.start, end: saved.end, waypoints: [] });
+    setStartCoords(null);
+    setEndCoords(null);
     setRouteOptions([]);
     setSelectedRouteIndex(null);
     setRouteUrl(saved.routeUrl);
     setWazeUrl(saved.wazeUrl);
     setStatusMessage({ type: 'info', text: `Loaded "${saved.name}". Scan the QR code or press "Find Scenic Routes" to regenerate options.` });
+  };
+
+  const handleStartChange = (start: string) => {
+    setRoute(prev => ({ ...prev, start }));
+    setStartCoords(null);
+  };
+
+  const handleEndChange = (end: string) => {
+    setRoute(prev => ({ ...prev, end }));
+    setEndCoords(null);
+  };
+
+  const handleStartSelect = (suggestion: LocationSuggestion) => {
+    setRoute(prev => ({ ...prev, start: suggestion.label }));
+    setStartCoords({ lat: suggestion.lat, lon: suggestion.lon });
+  };
+
+  const handleEndSelect = (suggestion: LocationSuggestion) => {
+    setRoute(prev => ({ ...prev, end: suggestion.label }));
+    setEndCoords({ lat: suggestion.lat, lon: suggestion.lon });
   };
 
   const handleDeleteSavedRoute = (id: string) => {
@@ -316,8 +358,11 @@ function App() {
                 start={route.start}
                 end={route.end}
                 isLoading={isLoadingSuggestions}
-                onStartChange={(start) => setRoute(prev => ({ ...prev, start }))}
-                onEndChange={(end) => setRoute(prev => ({ ...prev, end }))}
+                loadingStatus={loadingStatus}
+                onStartChange={handleStartChange}
+                onEndChange={handleEndChange}
+                onStartSelect={handleStartSelect}
+                onEndSelect={handleEndSelect}
                 onSearch={handleSearch}
               />
 
@@ -325,6 +370,7 @@ function App() {
                 routeOptions={routeOptions}
                 selectedRouteIndex={selectedRouteIndex}
                 isLoading={isLoadingSuggestions}
+                loadingStatus={loadingStatus}
                 onSelectRoute={setSelectedRouteIndex}
                 onToggleWaypoint={toggleSuggestedWaypoint}
               />
@@ -367,6 +413,9 @@ function App() {
       <div className="map-container">
         <InteractiveMap
           onLoad={onMapLoad}
+          selectedRoute={selectedRoute}
+          startCoords={startCoords}
+          endCoords={endCoords}
         />
       </div>
     </div>

--- a/canyon-tour/src/InteractiveMap.tsx
+++ b/canyon-tour/src/InteractiveMap.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import { GoogleMap, useJsApiLoader } from '@react-google-maps/api';
 import { getGoogleMapsApiKey } from './utils/env';
+import RoutePreview from './components/RoutePreview';
+import { Coordinates, RouteOption } from './types';
 
 interface MapProps {
   onLoad: (map: google.maps.Map) => void;
+  selectedRoute?: RouteOption | null;
+  startCoords?: Coordinates | null;
+  endCoords?: Coordinates | null;
 }
 
 const containerStyle = {
@@ -16,31 +21,17 @@ const defaultCenter = {
   lng: -117.1611
 };
 
-const MissingKeyNotice: React.FC = () => (
-  <div className="flex items-center justify-center h-full bg-gray-100 p-8">
-    <div className="max-w-md text-center">
-      <div className="text-5xl mb-4">🗺️</div>
-      <h3 className="text-lg font-semibold text-gray-800 mb-2">Map preview unavailable</h3>
-      <p className="text-sm text-gray-600">
-        Add <code className="bg-gray-200 px-1 rounded">VITE_GOOGLE_MAPS_API_KEY</code> to your
-        <code className="bg-gray-200 px-1 rounded ml-1">.env</code> file to display the interactive map.
-        Route discovery, Google Maps links, and QR codes still work without it.
-      </p>
-    </div>
-  </div>
-);
-
-const InteractiveMap: React.FC<MapProps> = ({ onLoad }) => {
+const InteractiveMap: React.FC<MapProps> = ({ onLoad, selectedRoute = null, startCoords = null, endCoords = null }) => {
   const apiKey = getGoogleMapsApiKey();
 
   if (!apiKey) {
-    return <MissingKeyNotice />;
+    return <RoutePreview route={selectedRoute} start={startCoords} end={endCoords} />;
   }
 
   return <LoadedMap apiKey={apiKey} onLoad={onLoad} />;
 };
 
-const LoadedMap: React.FC<MapProps & { apiKey: string }> = ({ apiKey, onLoad }) => {
+const LoadedMap: React.FC<{ apiKey: string; onLoad: (map: google.maps.Map) => void }> = ({ apiKey, onLoad }) => {
   const { isLoaded } = useJsApiLoader({
     id: 'google-map-script',
     googleMapsApiKey: apiKey

--- a/canyon-tour/src/components/LocationAutocomplete.test.tsx
+++ b/canyon-tour/src/components/LocationAutocomplete.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import LocationAutocomplete from './LocationAutocomplete';
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          display_name: 'Jamul, San Diego County, California, USA',
+          lat: '32.717',
+          lon: '-116.876',
+        },
+        {
+          display_name: 'Jamul Indian Village, California, USA',
+          lat: '32.700',
+          lon: '-116.850',
+        },
+      ],
+    })
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('LocationAutocomplete', () => {
+  test('fetches and shows Nominatim suggestions after debounce', async () => {
+    const onChange = vi.fn();
+
+    const { rerender } = render(
+      <LocationAutocomplete id="start" label="Start" value="" onChange={onChange} />
+    );
+
+    // Controlled input: parent would update value from onChange.
+    rerender(
+      <LocationAutocomplete id="start" label="Start" value="Jamul" onChange={onChange} />
+    );
+
+    await waitFor(
+      () => {
+        expect(fetch).toHaveBeenCalled();
+        expect(screen.getByRole('listbox')).toBeInTheDocument();
+      },
+      { timeout: 2000 }
+    );
+
+    expect(screen.getByText(/Jamul, San Diego County/)).toBeInTheDocument();
+    expect(screen.getByText(/Jamul Indian Village/)).toBeInTheDocument();
+  });
+
+  test('selecting a suggestion calls onSelect with coords', async () => {
+    const onChange = vi.fn();
+    const onSelect = vi.fn();
+
+    const { rerender } = render(
+      <LocationAutocomplete
+        id="start"
+        label="Start"
+        value="Jamul"
+        onChange={onChange}
+        onSelect={onSelect}
+      />
+    );
+
+    // Re-render to ensure effect sees value (same as mount with value).
+    rerender(
+      <LocationAutocomplete
+        id="start"
+        label="Start"
+        value="Jamul"
+        onChange={onChange}
+        onSelect={onSelect}
+      />
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByRole('listbox')).toBeInTheDocument();
+      },
+      { timeout: 2000 }
+    );
+
+    fireEvent.mouseDown(screen.getByText(/Jamul, San Diego County/));
+
+    expect(onSelect).toHaveBeenCalledWith({
+      label: 'Jamul, San Diego County, California, USA',
+      lat: 32.717,
+      lon: -116.876,
+    });
+    expect(onChange).toHaveBeenCalledWith('Jamul, San Diego County, California, USA');
+  });
+});

--- a/canyon-tour/src/components/LocationAutocomplete.tsx
+++ b/canyon-tour/src/components/LocationAutocomplete.tsx
@@ -79,8 +79,16 @@ const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
           lat: parseFloat(r.lat),
           lon: parseFloat(r.lon),
         }));
-        setSuggestions(mapped);
-        setOpen(mapped.length > 0);
+        // Nominatim sometimes returns near-identical hits; keep the first of each cluster.
+        const seen = new Set<string>();
+        const unique = mapped.filter(s => {
+          const key = `${s.lat.toFixed(4)},${s.lon.toFixed(4)}`;
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+        setSuggestions(unique);
+        setOpen(unique.length > 0);
         setActiveIndex(-1);
       } catch (error: unknown) {
         if (!(error instanceof DOMException && error.name === 'AbortError')) {

--- a/canyon-tour/src/components/LocationAutocomplete.tsx
+++ b/canyon-tour/src/components/LocationAutocomplete.tsx
@@ -1,0 +1,184 @@
+import React, { useEffect, useId, useRef, useState } from 'react';
+
+export interface LocationSuggestion {
+  label: string;
+  lat: number;
+  lon: number;
+}
+
+interface LocationAutocompleteProps {
+  id: string;
+  label: string;
+  value: string;
+  placeholder?: string;
+  disabled?: boolean;
+  onChange: (value: string) => void;
+  onSelect?: (suggestion: LocationSuggestion) => void;
+}
+
+/**
+ * Debounced Nominatim search-as-you-type for start/end locations.
+ * Works without a Google API key.
+ */
+const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
+  id,
+  label,
+  value,
+  placeholder,
+  disabled,
+  onChange,
+  onSelect,
+}) => {
+  const listId = useId();
+  const [suggestions, setSuggestions] = useState<LocationSuggestion[]>([]);
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [isSearching, setIsSearching] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const blurTimeoutRef = useRef<number | null>(null);
+  const skipSearchRef = useRef(false);
+
+  useEffect(() => {
+    if (skipSearchRef.current) {
+      skipSearchRef.current = false;
+      return;
+    }
+
+    const query = value.trim();
+    const timer = window.setTimeout(async () => {
+      if (query.length < 3 || disabled) {
+        setSuggestions([]);
+        setOpen(false);
+        return;
+      }
+
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setIsSearching(true);
+
+      try {
+        const url =
+          `https://nominatim.openstreetmap.org/search?format=json&addressdetails=0&limit=5` +
+          `&q=${encodeURIComponent(query)}`;
+        const response = await fetch(url, {
+          signal: controller.signal,
+          headers: { Accept: 'application/json' },
+        });
+        if (!response.ok) {
+          setSuggestions([]);
+          return;
+        }
+        const results = await response.json();
+        if (!Array.isArray(results)) {
+          setSuggestions([]);
+          return;
+        }
+        const mapped: LocationSuggestion[] = results.map((r: { display_name: string; lat: string; lon: string }) => ({
+          label: r.display_name,
+          lat: parseFloat(r.lat),
+          lon: parseFloat(r.lon),
+        }));
+        setSuggestions(mapped);
+        setOpen(mapped.length > 0);
+        setActiveIndex(-1);
+      } catch (error: unknown) {
+        if (!(error instanceof DOMException && error.name === 'AbortError')) {
+          setSuggestions([]);
+        }
+      } finally {
+        setIsSearching(false);
+      }
+    }, 350);
+
+    return () => {
+      window.clearTimeout(timer);
+      abortRef.current?.abort();
+    };
+  }, [value, disabled]);
+
+  const choose = (suggestion: LocationSuggestion) => {
+    skipSearchRef.current = true;
+    onChange(suggestion.label);
+    onSelect?.(suggestion);
+    setSuggestions([]);
+    setOpen(false);
+    setActiveIndex(-1);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open || suggestions.length === 0) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex(i => (i + 1) % suggestions.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex(i => (i <= 0 ? suggestions.length - 1 : i - 1));
+    } else if (e.key === 'Enter' && activeIndex >= 0) {
+      e.preventDefault();
+      choose(suggestions[activeIndex]);
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className="location-input-group relative">
+      <label htmlFor={id}>{label}</label>
+      <input
+        id={id}
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-autocomplete="list"
+        aria-activedescendant={activeIndex >= 0 ? `${listId}-opt-${activeIndex}` : undefined}
+        value={value}
+        disabled={disabled}
+        autoComplete="off"
+        onChange={(e) => onChange(e.target.value)}
+        onFocus={() => {
+          if (suggestions.length > 0) setOpen(true);
+        }}
+        onBlur={() => {
+          // Delay so a mousedown on a suggestion still registers.
+          blurTimeoutRef.current = window.setTimeout(() => setOpen(false), 150);
+        }}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+      />
+      {isSearching && (
+        <div className="absolute right-3 top-9 text-xs text-gray-400">Searching…</div>
+      )}
+      {open && suggestions.length > 0 && (
+        <ul
+          id={listId}
+          role="listbox"
+          className="absolute z-20 left-0 right-0 mt-1 max-h-56 overflow-y-auto bg-white border border-gray-200 rounded-md shadow-lg"
+        >
+          {suggestions.map((suggestion, index) => (
+            <li
+              key={`${suggestion.lat},${suggestion.lon},${index}`}
+              id={`${listId}-opt-${index}`}
+              role="option"
+              aria-selected={index === activeIndex}
+              className={`px-3 py-2 text-sm cursor-pointer ${
+                index === activeIndex ? 'bg-blue-50 text-blue-900' : 'text-gray-800 hover:bg-gray-50'
+              }`}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                if (blurTimeoutRef.current) window.clearTimeout(blurTimeoutRef.current);
+                choose(suggestion);
+              }}
+              onMouseEnter={() => setActiveIndex(index)}
+            >
+              {suggestion.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default LocationAutocomplete;

--- a/canyon-tour/src/components/RouteForm.tsx
+++ b/canyon-tour/src/components/RouteForm.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
+import LocationAutocomplete, { LocationSuggestion } from './LocationAutocomplete';
 
 interface RouteFormProps {
   start: string;
   end: string;
   isLoading: boolean;
+  loadingStatus?: string | null;
   onStartChange: (value: string) => void;
   onEndChange: (value: string) => void;
+  onStartSelect?: (suggestion: LocationSuggestion) => void;
+  onEndSelect?: (suggestion: LocationSuggestion) => void;
   onSearch: () => void;
 }
 
@@ -13,39 +17,40 @@ const RouteForm: React.FC<RouteFormProps> = ({
   start,
   end,
   isLoading,
+  loadingStatus,
   onStartChange,
   onEndChange,
+  onStartSelect,
+  onEndSelect,
   onSearch,
 }) => (
   <div className="location-controls">
-    <div className="location-input-group">
-      <label htmlFor="start-location">Start Location</label>
-      <input
-        id="start-location"
-        type="text"
-        value={start}
-        onChange={(e) => onStartChange(e.target.value)}
-        placeholder="Enter starting location"
-      />
-    </div>
+    <LocationAutocomplete
+      id="start-location"
+      label="Start Location"
+      value={start}
+      disabled={isLoading}
+      onChange={onStartChange}
+      onSelect={onStartSelect}
+      placeholder="Enter starting location"
+    />
 
-    <div className="location-input-group">
-      <label htmlFor="end-location">End Location</label>
-      <input
-        id="end-location"
-        type="text"
-        value={end}
-        onChange={(e) => onEndChange(e.target.value)}
-        placeholder="Enter destination"
-      />
-    </div>
+    <LocationAutocomplete
+      id="end-location"
+      label="End Location"
+      value={end}
+      disabled={isLoading}
+      onChange={onEndChange}
+      onSelect={onEndSelect}
+      placeholder="Enter destination"
+    />
 
     <button
       onClick={onSearch}
       className="w-full px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors font-medium"
       disabled={!start || !end || isLoading}
     >
-      {isLoading ? 'Finding Routes...' : 'Find Scenic Routes'}
+      {isLoading ? (loadingStatus || 'Finding Routes...') : 'Find Scenic Routes'}
     </button>
   </div>
 );

--- a/canyon-tour/src/components/RouteOptionsPanel.tsx
+++ b/canyon-tour/src/components/RouteOptionsPanel.tsx
@@ -5,6 +5,7 @@ interface RouteOptionsPanelProps {
   routeOptions: RouteOption[];
   selectedRouteIndex: number | null;
   isLoading: boolean;
+  loadingStatus?: string | null;
   onSelectRoute: (index: number) => void;
   onToggleWaypoint: (id: string) => void;
 }
@@ -13,6 +14,7 @@ const RouteOptionsPanel: React.FC<RouteOptionsPanelProps> = ({
   routeOptions,
   selectedRouteIndex,
   isLoading,
+  loadingStatus,
   onSelectRoute,
   onToggleWaypoint,
 }) => {
@@ -31,7 +33,9 @@ const RouteOptionsPanel: React.FC<RouteOptionsPanelProps> = ({
       {isLoading ? (
         <div className="flex items-center space-x-3 py-4">
           <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
-          <div className="text-blue-600 font-medium">Analyzing roads for maximum twistiness...</div>
+          <div className="text-blue-600 font-medium">
+            {loadingStatus || 'Analyzing roads for maximum twistiness...'}
+          </div>
         </div>
       ) : (
         <div className="space-y-3">

--- a/canyon-tour/src/components/RoutePreview.tsx
+++ b/canyon-tour/src/components/RoutePreview.tsx
@@ -1,0 +1,150 @@
+import React, { useMemo } from 'react';
+import { Coordinates, RouteOption } from '../types';
+import { buildRoutePreviewView } from './routePreviewGeometry';
+
+interface RoutePreviewProps {
+  route: RouteOption | null;
+  start?: Coordinates | null;
+  end?: Coordinates | null;
+}
+
+/**
+ * SVG path preview used when Google Maps is unavailable (no API key).
+ * Renders the selected route's graph geometry with start/end markers.
+ */
+const RoutePreview: React.FC<RoutePreviewProps> = ({ route, start, end }) => {
+  const geometry = route?.pathGeometry;
+
+  const view = useMemo(() => {
+    const points: Coordinates[] = [];
+    if (geometry && geometry.length > 0) points.push(...geometry);
+    if (start) points.push(start);
+    if (end) points.push(end);
+    return buildRoutePreviewView(points);
+  }, [geometry, start, end]);
+
+  if (!view) {
+    return (
+      <div className="flex items-center justify-center h-full bg-slate-100 p-8">
+        <div className="max-w-md text-center">
+          <div className="text-5xl mb-4">🗺️</div>
+          <h3 className="text-lg font-semibold text-gray-800 mb-2">Route preview</h3>
+          <p className="text-sm text-gray-600">
+            Find scenic routes to see the selected path drawn here. Add a
+            <code className="bg-gray-200 px-1 rounded mx-1">VITE_GOOGLE_MAPS_API_KEY</code>
+            for the interactive Google map.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const { WIDTH, HEIGHT, project } = view;
+  const pathPoints = (geometry || []).map(project);
+  const pathD = pathPoints
+    .map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`)
+    .join(' ');
+  const startPt = start ? project(start) : pathPoints[0];
+  const endPt = end ? project(end) : pathPoints[pathPoints.length - 1];
+  const waypointPts = (route?.waypoints || [])
+    .filter(wp => wp.checked && wp.coordinates)
+    .map(wp => ({ ...project(wp.coordinates!), label: wp.location }));
+
+  return (
+    <div className="relative h-full w-full bg-slate-50">
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        className="h-full w-full"
+        role="img"
+        aria-label={route ? `Preview of ${route.name}` : 'Route preview'}
+      >
+        <rect width={WIDTH} height={HEIGHT} fill="#f1f5f9" />
+        {Array.from({ length: 8 }).map((_, i) => (
+          <line
+            key={`h-${i}`}
+            x1={0}
+            y1={(HEIGHT / 8) * i}
+            x2={WIDTH}
+            y2={(HEIGHT / 8) * i}
+            stroke="#e2e8f0"
+            strokeWidth={1}
+          />
+        ))}
+        {Array.from({ length: 10 }).map((_, i) => (
+          <line
+            key={`v-${i}`}
+            x1={(WIDTH / 10) * i}
+            y1={0}
+            x2={(WIDTH / 10) * i}
+            y2={HEIGHT}
+            stroke="#e2e8f0"
+            strokeWidth={1}
+          />
+        ))}
+
+        {pathD && (
+          <path
+            d={pathD}
+            fill="none"
+            stroke="#e63946"
+            strokeWidth={4}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            opacity={0.9}
+          />
+        )}
+
+        {waypointPts.map((wp, i) => (
+          <g key={i}>
+            <circle cx={wp.x} cy={wp.y} r={6} fill="#f97316" stroke="#fff" strokeWidth={2} />
+            <text
+              x={wp.x + 10}
+              y={wp.y + 4}
+              fontSize={11}
+              fill="#475569"
+              fontFamily="system-ui, sans-serif"
+            >
+              {i + 1}
+            </text>
+          </g>
+        ))}
+
+        {startPt && (
+          <g>
+            <circle cx={startPt.x} cy={startPt.y} r={9} fill="#2a9d8f" stroke="#fff" strokeWidth={2} />
+            <text x={startPt.x + 14} y={startPt.y + 5} fontSize={14} fill="#2a9d8f" fontFamily="system-ui, sans-serif" fontWeight={600}>
+              START
+            </text>
+          </g>
+        )}
+        {endPt && (
+          <g>
+            <circle cx={endPt.x} cy={endPt.y} r={9} fill="#264653" stroke="#fff" strokeWidth={2} />
+            <text x={endPt.x + 14} y={endPt.y + 5} fontSize={14} fill="#264653" fontFamily="system-ui, sans-serif" fontWeight={600}>
+              END
+            </text>
+          </g>
+        )}
+      </svg>
+
+      {route && (
+        <div className="absolute top-3 left-3 bg-white/90 backdrop-blur-sm border border-slate-200 rounded-md px-3 py-2 shadow-sm max-w-sm">
+          <div className="font-semibold text-sm text-slate-800">{route.name}</div>
+          <div className="text-xs text-slate-500 mt-0.5">
+            {route.distance !== undefined && `${route.distance.toFixed(0)} km`}
+            {route.duration !== undefined && ` · ${formatDuration(route.duration)}`}
+            {route.totalTwistiness !== undefined && ` · twistiness ${route.totalTwistiness.toFixed(1)}`}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+function formatDuration(minutes: number): string {
+  const hours = Math.floor(minutes / 60);
+  const mins = Math.round(minutes % 60);
+  return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
+}
+
+export default RoutePreview;

--- a/canyon-tour/src/components/routePreviewGeometry.test.ts
+++ b/canyon-tour/src/components/routePreviewGeometry.test.ts
@@ -1,0 +1,35 @@
+import { buildRoutePreviewView } from './routePreviewGeometry';
+
+describe('buildRoutePreviewView', () => {
+  test('returns null for empty input', () => {
+    expect(buildRoutePreviewView([])).toBeNull();
+  });
+
+  test('projects points inside the SVG bounds', () => {
+    const view = buildRoutePreviewView([
+      { lat: 32.7, lon: -116.9 },
+      { lat: 32.75, lon: -116.8 },
+      { lat: 32.72, lon: -116.85 },
+    ]);
+    expect(view).not.toBeNull();
+    const { WIDTH, HEIGHT, project } = view!;
+
+    const a = project({ lat: 32.7, lon: -116.9 });
+    const b = project({ lat: 32.75, lon: -116.8 });
+
+    expect(a.x).toBeGreaterThanOrEqual(0);
+    expect(a.x).toBeLessThanOrEqual(WIDTH);
+    expect(a.y).toBeGreaterThanOrEqual(0);
+    expect(a.y).toBeLessThanOrEqual(HEIGHT);
+    expect(b.x).toBeGreaterThan(a.x); // east is to the right
+    expect(b.y).toBeLessThan(a.y); // north is up (smaller y)
+  });
+
+  test('handles a single point without NaN', () => {
+    const view = buildRoutePreviewView([{ lat: 33.0, lon: -117.0 }]);
+    expect(view).not.toBeNull();
+    const p = view!.project({ lat: 33.0, lon: -117.0 });
+    expect(Number.isFinite(p.x)).toBe(true);
+    expect(Number.isFinite(p.y)).toBe(true);
+  });
+});

--- a/canyon-tour/src/components/routePreviewGeometry.ts
+++ b/canyon-tour/src/components/routePreviewGeometry.ts
@@ -1,0 +1,56 @@
+import { Coordinates } from '../types';
+
+export interface RoutePreviewView {
+  WIDTH: number;
+  HEIGHT: number;
+  project: (p: Coordinates) => { x: number; y: number };
+}
+
+/**
+ * Builds an SVG projection for a set of geographic points, preserving
+ * aspect ratio with a cosine correction for longitude at mid-latitude.
+ */
+export function buildRoutePreviewView(
+  points: Coordinates[],
+  width = 800,
+  height = 600
+): RoutePreviewView | null {
+  if (points.length === 0) return null;
+
+  let minLat = Infinity;
+  let maxLat = -Infinity;
+  let minLon = Infinity;
+  let maxLon = -Infinity;
+  for (const p of points) {
+    minLat = Math.min(minLat, p.lat);
+    maxLat = Math.max(maxLat, p.lat);
+    minLon = Math.min(minLon, p.lon);
+    maxLon = Math.max(maxLon, p.lon);
+  }
+
+  const latPad = Math.max((maxLat - minLat) * 0.08, 0.005);
+  const lonPad = Math.max((maxLon - minLon) * 0.08, 0.005);
+  minLat -= latPad;
+  maxLat += latPad;
+  minLon -= lonPad;
+  maxLon += lonPad;
+
+  const latSpan = maxLat - minLat || 0.01;
+  const lonSpan = maxLon - minLon || 0.01;
+  const midLat = (minLat + maxLat) / 2;
+  const lonScale = Math.cos((midLat * Math.PI) / 180);
+  const geoWidth = lonSpan * lonScale;
+  const geoHeight = latSpan;
+  const scale = Math.min(width / geoWidth, height / geoHeight);
+  const offsetX = (width - geoWidth * scale) / 2;
+  const offsetY = (height - geoHeight * scale) / 2;
+
+  return {
+    WIDTH: width,
+    HEIGHT: height,
+    project: (p: Coordinates) => ({
+      x: offsetX + (p.lon - minLon) * lonScale * scale,
+      y: offsetY + (maxLat - p.lat) * scale,
+    }),
+  };
+}

--- a/canyon-tour/src/testUtils/syntheticOsm.ts
+++ b/canyon-tour/src/testUtils/syntheticOsm.ts
@@ -73,3 +73,85 @@ export function buildSyntheticNetwork(): { elements: any[] } {
 
   return { elements };
 }
+
+/**
+ * Three parallel corridors so edge-penalized alternatives can diverge:
+ * straight (shortest), medium-curve, and high-twistiness.
+ */
+export function buildSyntheticNetworkWithAlternatives(): { elements: any[] } {
+  const elements: any[] = [];
+
+  const addNode = (id: number, lat: number, lon: number) => {
+    elements.push({ type: 'node', id, lat, lon });
+  };
+
+  addNode(NODE_A_ID, BASE_LAT, WEST_LON);
+  addNode(NODE_B_ID, BASE_LAT, EAST_LON);
+
+  const straightNodeIds = [NODE_A_ID];
+  for (let i = 1; i <= 4; i++) {
+    const id = 100 + i;
+    addNode(id, BASE_LAT, WEST_LON + (EAST_LON - WEST_LON) * (i / 5));
+    straightNodeIds.push(id);
+  }
+  straightNodeIds.push(NODE_B_ID);
+  elements.push({
+    type: 'way',
+    id: 1000,
+    nodes: straightNodeIds,
+    tags: {
+      highway: 'secondary',
+      lanes: '2',
+      surface: 'asphalt',
+      maxspeed: '55 mph',
+      name: 'Straight Road',
+    },
+  });
+
+  // Medium corridor: gentle north offset.
+  const mediumNodeIds = [NODE_A_ID];
+  for (let i = 1; i < 8; i++) {
+    const id = 300 + i;
+    const lat = BASE_LAT + (i % 2 === 1 ? 0.004 : 0);
+    addNode(id, lat, WEST_LON + (EAST_LON - WEST_LON) * (i / 8));
+    mediumNodeIds.push(id);
+  }
+  mediumNodeIds.push(NODE_B_ID);
+  elements.push({
+    type: 'way',
+    id: 3000,
+    nodes: mediumNodeIds,
+    tags: {
+      highway: 'secondary',
+      lanes: '2',
+      surface: 'asphalt',
+      maxspeed: '55 mph',
+      name: 'Medium Road',
+    },
+  });
+
+  // High-twistiness corridor: large zigzag.
+  const twistyNodeIds = [NODE_A_ID];
+  const steps = 10;
+  for (let i = 1; i < steps; i++) {
+    const id = 200 + i;
+    const lat = BASE_LAT + (i % 2 === 1 ? 0.012 : 0);
+    addNode(id, lat, WEST_LON + (EAST_LON - WEST_LON) * (i / steps));
+    twistyNodeIds.push(id);
+  }
+  twistyNodeIds.push(NODE_B_ID);
+  elements.push({
+    type: 'way',
+    id: 2000,
+    nodes: twistyNodeIds,
+    tags: {
+      highway: 'secondary',
+      lanes: '2',
+      surface: 'asphalt',
+      maxspeed: '55 mph',
+      name: 'Twisty Road',
+    },
+  });
+
+  return { elements };
+}

--- a/canyon-tour/src/utils/routing/graphRouteGenerator.test.ts
+++ b/canyon-tour/src/utils/routing/graphRouteGenerator.test.ts
@@ -4,7 +4,7 @@ import { findBestPath, ROUTE_PROFILES } from './graphRouter';
 import { Coordinates } from '../../types';
 import { getDirections } from '../../services/googleMapsService';
 import { makeMockDirectionsResult } from '../../testUtils/mockDirections';
-import { buildSyntheticNetwork } from '../../testUtils/syntheticOsm';
+import { buildSyntheticNetwork, buildSyntheticNetworkWithAlternatives } from '../../testUtils/syntheticOsm';
 
 vi.mock('../../services/googleMapsService', () => ({
   getDirections: vi.fn(),
@@ -84,7 +84,35 @@ describe('generateScenicRouteOptions', () => {
       expect(option.distance).toBeGreaterThan(5);
       expect(option.duration).toBeGreaterThan(0);
       expect(option.waypoints.length).toBeGreaterThan(0);
+      expect(option.pathGeometry?.length).toBeGreaterThan(1);
     });
+  });
+
+  test('includes pathGeometry for SVG preview', async () => {
+    const options = await generateScenicRouteOptions(buildSyntheticNetwork(), start, end);
+    options.forEach(option => {
+      expect(option.pathGeometry).toBeDefined();
+      expect(option.pathGeometry!.length).toBeGreaterThan(1);
+      option.pathGeometry!.forEach(p => {
+        expect(typeof p.lat).toBe('number');
+        expect(typeof p.lon).toBe('number');
+      });
+    });
+  });
+
+  test('produces an alternative when parallel corridors exist', async () => {
+    const options = await generateScenicRouteOptions(
+      buildSyntheticNetworkWithAlternatives(),
+      start,
+      end
+    );
+
+    expect(options.length).toBeGreaterThanOrEqual(2);
+    const alt = options.find(o => o.name.includes('Alternative'));
+    // With three corridors, edge penalties should surface at least one alternative
+    // once Twisty + Direct claim the two extremes.
+    expect(alt).toBeDefined();
+    expect(alt!.pathGeometry!.length).toBeGreaterThan(1);
   });
 
   test('returns empty list when the area has no suitable roads', async () => {

--- a/canyon-tour/src/utils/routing/graphRouteGenerator.ts
+++ b/canyon-tour/src/utils/routing/graphRouteGenerator.ts
@@ -56,8 +56,12 @@ export async function generateScenicRouteOptions(
   for (const profile of ROUTE_PROFILES) {
     const path = findBestPath(graph, startNode.id, endNode.id, profile);
     if (!path) continue;
-    // Skip profiles that resolve to (almost) the same road choice as one we have.
-    const isDuplicate = paths.some(existing => pathOverlapFraction(path, existing.path) > PROFILE_DEDUP_OVERLAP);
+    // Always keep Most Direct as a length baseline, even when it shares most
+    // of its edges with a scenic profile (common on single-corridor trips).
+    const isDirect = profile.name === 'Most Direct';
+    const isDuplicate =
+      !isDirect &&
+      paths.some(existing => pathOverlapFraction(path, existing.path) > PROFILE_DEDUP_OVERLAP);
     if (!isDuplicate) {
       paths.push({ profile, path });
     }

--- a/canyon-tour/src/utils/routing/graphRouteGenerator.ts
+++ b/canyon-tour/src/utils/routing/graphRouteGenerator.ts
@@ -23,6 +23,8 @@ const ENDPOINT_CLEARANCE_METERS = 1500;
 const MAX_SNAP_DISTANCE_METERS = 30000;
 /** Alternatives sharing more than this fraction of an existing route are dropped. */
 const MAX_OVERLAP_FRACTION = 0.7;
+/** Profile results sharing more than this of an existing path are treated as duplicates. */
+const PROFILE_DEDUP_OVERLAP = 0.9;
 
 export async function generateScenicRouteOptions(
   osmData: { elements: any[] },
@@ -55,7 +57,7 @@ export async function generateScenicRouteOptions(
     const path = findBestPath(graph, startNode.id, endNode.id, profile);
     if (!path) continue;
     // Skip profiles that resolve to (almost) the same road choice as one we have.
-    const isDuplicate = paths.some(existing => pathOverlapFraction(path, existing.path) > 0.95);
+    const isDuplicate = paths.some(existing => pathOverlapFraction(path, existing.path) > PROFILE_DEDUP_OVERLAP);
     if (!isDuplicate) {
       paths.push({ profile, path });
     }
@@ -66,17 +68,28 @@ export async function generateScenicRouteOptions(
     return [];
   }
 
-  // Generate a genuinely different scenic alternative by penalizing the edges
-  // of the best scenic path and re-routing.
+  // Generate meaningfully different scenic alternatives by escalating edge
+  // penalties on already-chosen corridors and re-routing. Produces up to two
+  // alternatives so the options panel isn't a single card when the corridor
+  // has parallel scenic roads.
   const scenicBase = paths.find(p => p.profile.name === 'Twisty Explorer') ?? paths[0];
-  const penalties = new Map<string, number>();
-  scenicBase.path.edges.forEach(edge => penalties.set(edge.id, 2.5));
-  const alternativePath = findBestPath(graph, startNode.id, endNode.id, scenicBase.profile, penalties);
-  if (
-    alternativePath &&
-    paths.every(existing => pathOverlapFraction(alternativePath, existing.path) < MAX_OVERLAP_FRACTION)
-  ) {
-    paths.push({ profile: scenicBase.profile, path: alternativePath, nameSuffix: ' (Alternative)' });
+  const usedEdgeIds = new Set(paths.flatMap(p => p.path.edges.map(edge => edge.id)));
+  const penaltyLevels = [2.5, 4.5];
+  let alternativeCount = 0;
+
+  for (const penalty of penaltyLevels) {
+    const penalties = new Map<string, number>();
+    usedEdgeIds.forEach(id => penalties.set(id, penalty));
+    const alternativePath = findBestPath(graph, startNode.id, endNode.id, scenicBase.profile, penalties);
+    if (
+      alternativePath &&
+      paths.every(existing => pathOverlapFraction(alternativePath, existing.path) < MAX_OVERLAP_FRACTION)
+    ) {
+      alternativeCount += 1;
+      const suffix = alternativeCount === 1 ? ' (Alternative)' : ` (Alternative ${alternativeCount})`;
+      paths.push({ profile: scenicBase.profile, path: alternativePath, nameSuffix: suffix });
+      alternativePath.edges.forEach(edge => usedEdgeIds.add(edge.id));
+    }
   }
 
   const options: RouteOption[] = [];

--- a/canyon-tour/src/utils/routing/graphRouter.ts
+++ b/canyon-tour/src/utils/routing/graphRouter.ts
@@ -33,26 +33,30 @@ export const ROUTE_PROFILES: RouteProfile[] = [
   {
     name: 'Twisty Explorer',
     description: 'Maximizes curvy 2-lane secondary roads, accepting longer detours.',
-    twistinessWeight: 0.55,
-    highwayMultipliers: { secondary: 0.6, tertiary: 0.75, unclassified: 0.9, residential: 1.4, primary: 1.1 },
-    straightPenalty: 1.25,
-    idealSpeedMultiplier: 0.85,
-    twoLaneMultiplier: 0.9,
+    // Strong curvature discount + heavy straight-road penalty so this profile
+    // will take a longer corridor when a twistier one exists.
+    twistinessWeight: 0.7,
+    highwayMultipliers: { secondary: 0.5, tertiary: 0.65, unclassified: 0.8, residential: 1.6, primary: 1.35 },
+    straightPenalty: 1.6,
+    idealSpeedMultiplier: 0.8,
+    twoLaneMultiplier: 0.85,
   },
   {
     name: 'Balanced Scenic',
     description: 'Prefers scenic roads with a moderate detour budget.',
-    twistinessWeight: 0.35,
-    highwayMultipliers: { secondary: 0.8, tertiary: 0.9, unclassified: 1.0, residential: 1.2, primary: 1.0 },
-    straightPenalty: 1.1,
+    twistinessWeight: 0.4,
+    highwayMultipliers: { secondary: 0.75, tertiary: 0.85, unclassified: 0.95, residential: 1.25, primary: 1.05 },
+    straightPenalty: 1.2,
     idealSpeedMultiplier: 0.9,
-    twoLaneMultiplier: 0.95,
+    twoLaneMultiplier: 0.92,
   },
   {
     name: 'Most Direct',
     description: 'Shortest allowed route (still avoids unpaved and narrow roads).',
+    // Pure length, but gently prefer higher-class roads so Direct doesn't
+    // collapse onto the same secondary corridor as Twisty by accident.
     twistinessWeight: 0,
-    highwayMultipliers: { secondary: 1, tertiary: 1, unclassified: 1, residential: 1, primary: 1 },
+    highwayMultipliers: { secondary: 1.05, tertiary: 1.05, unclassified: 1.1, residential: 1.2, primary: 0.95 },
     straightPenalty: 1,
     idealSpeedMultiplier: 1,
     twoLaneMultiplier: 1,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the keyless experience so the app is usable without a Google Maps API key, and makes route options more distinct.

### Keyless UX
- **SVG route path preview** when `VITE_GOOGLE_MAPS_API_KEY` is unset — draws the selected option’s `pathGeometry` with start/end/waypoint markers
- **Nominatim autocomplete** on start/end (debounced search-as-you-type); selecting a suggestion caches coordinates and skips a redundant geocode on search
- **Staged progress** during discovery: Geocoding → Fetching roads → Building routes (shown on the Find button and options panel)

### Route diversity
- Stronger Twisty Explorer discounts / straight-road penalty; Most Direct gently prefers primary so it doesn’t collapse onto the same secondary corridor
- Profile dedup overlap raised to 90%; up to **two** escalating edge-penalized scenic alternatives when parallel corridors exist
- Bugfix: alternative generation now correctly collects `path.edges` for penalties

### Tests / docs
- Preview geometry unit tests, autocomplete component tests, pathGeometry + alternative coverage on a 3-corridor synthetic network
- README + CLAUDE.md updated for keyless preview/autocomplete and alternatives

**Verification:** `npm test` (45), `npm run lint`, `npm run build` all pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ee0e50e-08af-48f2-b2c7-05f23fcd86ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ee0e50e-08af-48f2-b2c7-05f23fcd86ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

